### PR TITLE
Add minimum_chrome_version of 49

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,7 @@
   "description": "Record camera, Desktop, Windows, and tabs",
   "version": "1",
   "manifest_version": 2,
+  "minimum_chrome_version": 49,
   "icons": {
     "16": "icon.png",
     "128": "icon.png"


### PR DESCRIPTION
MediaRecorder is not available before Chrome 49.  This will keep it
from being installable from Chrome Web Store on Chrome 48 and below.
