### PR TITLE
stop recording on track ended

### DIFF
--- a/app.js
+++ b/app.js
@@ -250,7 +250,12 @@ function gotMediaStream(stream) {
   var video = document.querySelector("video");
   video.src = URL.createObjectURL(stream);
   localStream = stream;
-  stream.onended = function() { console.log("Ended"); };
+  stream.getTracks().forEach(function(track) {
+    track.addEventListener('ended', function() {
+      console.log(stream.id, 'track ended', track.kind, track.id);
+      stopRecording();
+    });
+  });
 
 
   
@@ -300,7 +305,11 @@ function gotMediaStream(stream) {
 function gotAudio(stream) {
   console.log("Received audio stream");
   audioStream = stream;
-  stream.onended = function() { console.log("Audio Ended"); };
+  stream.getTracks().forEach(function(track) {
+    track.addEventListener('ended', function() {
+      console.log(stream.id, 'track ended', track.kind, track.id);
+    });
+  });
 
 };
 


### PR DESCRIPTION
stops recording when the video track ends. This happens when the user clicks
the "stop sharing" button in the Chrome UI

I signed the google CLA for samples and adapter so submitting under those terms. On any other terms you prefer and that are applicable ;-)